### PR TITLE
Use Number type in viewBox

### DIFF
--- a/svg/_types.py
+++ b/svg/_types.py
@@ -41,10 +41,10 @@ class PreserveAspectRatio:
 
 @dataclass
 class ViewBoxSpec:
-    min_x: int
-    min_y: int
-    width: int
-    height: int
+    min_x: Number
+    min_y: Number
+    width: Number
+    height: Number
 
     def __str__(self) -> str:
         return f"{self.min_x} {self.min_y} {self.width} {self.height}"


### PR DESCRIPTION
The xsd has this wrong I think. W3 spec says "number" and seems to define number as something that can have a floating point (though admitedly I find this spec hard to parse). MDN also says `<number>` and links to [this](https://developer.mozilla.org/en-US/docs/Web/SVG/Content_type#number) which includes floating point. If you merge this I'll send a PR to the xsd repo too. 

My own use-case is defining the viewBox in mm for paper formats defined in inches. 