### PR TITLE
drop xml:lang

### DIFF
--- a/svg/elements.py
+++ b/svg/elements.py
@@ -25,7 +25,6 @@ class Element:
     id: Optional[str] = None
     tabindex: Optional[int] = None
     lang: Optional[str] = None
-    xml__lang: Optional[str] = None
 
     transform_origin: Optional[str] = None
     style: Optional[str] = None


### PR DESCRIPTION
`xml:lang` is deprecated: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xml:lang