### PR TITLE
Add '%' symbol to match lenght type in svg

### DIFF
--- a/svg/_types.py
+++ b/svg/_types.py
@@ -13,7 +13,7 @@ Number = Union[Decimal, float, int]
 @dataclass
 class Length:
     value: Number
-    unit: Literal["em", "ex", "px", "pt", "pc", "cm", "mm", "in"]
+    unit: Literal["em", "ex", "px", "pt", "pc", "cm", "mm", "in", "%"]
 
     def __str__(self) -> str:
         return f"{self.value}{self.unit}"


### PR DESCRIPTION
In this [page](https://developer.mozilla.org/en-US/docs/Web/SVG/Content_type#length), we can read this:

> When lengths are used in an SVG attribute, a <length\> is instead defined as follows:
	` length ::= number ("em" | "ex" | "px" | "in" | "cm" | "mm" | "pt" | "pc" | "%")? `

So, I added "%" at the end of the unit list to prevent IDEs to to throw a tantrum beacause of type, now `width=svg._types.Length(value=100, unit='%')` is valid

However, I would like to know if is there better variation of `width='100%'` who respect typing