### PR TITLE
Fix type of stdDeviation

### DIFF
--- a/svg/_filters.py
+++ b/svg/_filters.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
 
 from . import _mixins as m
 from ._transforms import Transform
@@ -249,7 +249,7 @@ class FeGaussianBlur(Element, m.FilterPrimitive):
     https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feGaussianBlur
     """
     element_name = "feGaussianBlur"
-    stdDeviation: Optional[Tuple[Number, Number]] = None
+    stdDeviation: Optional[Union[Number, Tuple[Number, Number]]] = None
     edgeMode: Optional[Literal["duplicate", "wrap", "none"]] = None
     in_: Optional[str] = None
     color_interpolation_filters: Optional[Literal["auto", "sRGB", "linearRGB", "inherit"]] = None
@@ -324,7 +324,7 @@ class FeDropShadow(Element, m.FilterPrimitive):
     dy: Optional[Any] = None
     flood_opacity: Optional[Number] = None
     flood_color: Optional[str] = None
-    stdDeviation: Optional[Tuple[Number, Number]] = None
+    stdDeviation: Optional[Union[Number, Tuple[Number, Number]]] = None
     class_: Optional[list[str]] = None
 
 


### PR DESCRIPTION
I have corrected the type of the [stdDeviation](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stdDeviation) attribute of [feDropShadow](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feDropShadow) and [feGaussianBlur](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feGaussianBlur) from `number` to `number-optional-number`.

For [feDropShadow](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feDropShadow) even the Mozilla site has the wrong type, but I have already created a [PR](https://github.com/mdn/content/pull/32359).

I considered creating a type `NumberOptionalNumber`, but it only seems to be used in these two cases.