### PR TITLE
Allow arbitrary attributes on svg elements (eg for HTMX)

### DIFF
--- a/svg/elements.py
+++ b/svg/elements.py
@@ -31,6 +31,7 @@ class Element:
     transform_origin: str | None = None
     style: str | None = None
     data: dict | None = None
+    attributes: dict | None = None
 
     @classmethod
     def _as_str(cls, val: Any) -> str:
@@ -51,7 +52,7 @@ class Element:
         for key, val in vars(self).items():
             if val is None:
                 continue
-            if key in ("elements", "text", "data"):
+            if key in ("elements", "text", "data", "attributes"):
                 continue
             key = key.rstrip("_")
             key = key.replace("__", ":")
@@ -63,6 +64,8 @@ class Element:
         props = " ".join(f'{k}="{v}"' for k, v in self.as_dict().items())
         if self.data:
             props += " " + " ".join(f'data-{k}="{v}"' for k, v in self.data.items())
+        if self.attributes:
+            props += " " + " ".join(f'{k}="{v}"' for k, v in self.attributes.items())
         if self.text:
             return f"<{self.element_name} {props}>{self.text}</{self.element_name}>"
         if self.elements:


### PR DESCRIPTION
I really appreciate this package thanks, it is really great to get full type based hints for each element type in my editor, and it seems to work cleanly and predictably.

For my use case, I wanted to be able to add attributes to some of my SVG elements to create some basic interactivity using [HTMX](https://htmx.org), for example clicking a rectangle might bring up some metadata elsewhere on the page.

In order to do this I needed to be able to add attributes such as `hx-get` and `hx-target` to an element. Thanks to the type hints I could see that data properties were facilitated by a dictionary, but that each attribute name would be prefixed with `data-`. I replicated this feature to print raw attributes from an `attributes` dict.

I guess this could result in duplication/conflict with existing prop names, so if it were adopted for wider potentially it could be called `raw_attributes` or something?

The HTMX use case worked perfectly, very satisfying.