### PR TITLE
fix: include FillStroke as parent class of G

### DIFF
--- a/svg/elements.py
+++ b/svg/elements.py
@@ -116,6 +116,7 @@ class G(
     m.GraphicsElementEvents,
     m.Color,
     m.Graphics,
+    m.FillStroke,
 ):
     """The <g> SVG element is a container used to group other SVG elements.
 


### PR DESCRIPTION
To be able to add group attributes such as `stroke` and have them inherited by the group's children, the definition of class **G** must include class **FillStroke** as one of its parents, otherwise an exception is raised.