### PR TITLE
Drop font-stretch

### DIFF
--- a/svg/_mixins.py
+++ b/svg/_mixins.py
@@ -50,12 +50,6 @@ class FontSpecification(AttrsMixin):
     font_family: str | None = None
     font_size: Length | Number | None = None
     font_size_adjust: Number | None | Literal["none"] = None
-    font_stretch: None | Literal[
-        "normal", "wider", "narrower",
-        "ultra-condensed", "extra-condensed", "semi-condensed",
-        "semi-expanded", "expanded", "extra-expanded", "ultra-expanded",
-        "inherit",
-    ] = None
     font_style: None | Literal[
         "normal", "italic", "oblique", "inherit",
     ] = None


### PR DESCRIPTION
[font-stretch](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-stretch) is deprecated. Svg.py has a policy to not provide any deprecated attributes to ensure that created SVG images are portable.