### PR TITLE
Implement arithmetic operations for Length class

### DIFF
--- a/svg/_types.py
+++ b/svg/_types.py
@@ -20,6 +20,46 @@ class Length:
     value: Number
     unit: Literal["em", "ex", "px", "pt", "pc", "cm", "mm", "in", "%"]
 
+    def __add__(self, other: Union[Length, Number]) -> Length:
+        if isinstance(other, Length):
+            if self.unit != other.unit:
+                raise ValueError(f"Cannot add Lengths with different units: {self.unit} != {other.unit}")
+            return Length(self.value + other.value, self.unit) # type: ignore
+        elif isinstance(other, (int, float, Decimal)):
+            return Length(self.value + other, self.unit) # type: ignore
+        return NotImplemented
+
+    def __radd__(self, other: Number) -> Length:
+        return self + other
+
+    def __sub__(self, other: Union[Length, Number]) -> Length:
+        if isinstance(other, Length):
+            if self.unit != other.unit:
+                raise ValueError("Cannot subtract Lengths with different units")
+            return Length(self.value - other.value, self.unit) # type: ignore
+        elif isinstance(other, (int, float, Decimal)):
+            return Length(self.value - other, self.unit) # type: ignore
+        return NotImplemented
+
+    def __rsub__(self, other: Number) -> Length:
+        return Length(other - self.value, self.unit) # type: ignore
+
+    def __mul__(self, other: Number) -> Length:
+        if isinstance(other, (int, float, Decimal)):
+            return Length(self.value * other, self.unit) # type: ignore
+        return NotImplemented
+
+    def __rmul__(self, other: Number) -> Length:
+        return self * other
+
+    def __truediv__(self, other: Number) -> Length:
+        if isinstance(other, (int, float, Decimal)):
+            return Length(self.value / other, self.unit) # type: ignore
+        return NotImplemented
+
+    def __neg__(self) -> Length:
+        return Length(-self.value, self.unit)
+
     def __str__(self) -> str:
         return f"{self.value}{self.unit}"
 

--- a/tests/test_lenght.py
+++ b/tests/test_lenght.py
@@ -1,0 +1,66 @@
+# test Length class operations
+from decimal import Decimal 
+import pytest
+from svg._types import Length
+
+@pytest.mark.parametrize(
+    "op, length1, length2, expected",
+    [
+        ("+", Length(10, "px"), Length(5, "px"), Length(15, "px")),
+        ("-", Length(10, "px"), Length(5, "px"), Length(5, "px")),
+        ("*", Length(10, "px"), 2, Length(20, "px")),
+        ("/", Length(10, "px"), 2, Length(5, "px")),
+        ("neg", Length(10, "px"), None, Length(-10, "px")),
+        ("+", Length(10, "px"), 5.0, Length(15.0, "px")),
+        ("-", 10.0, Length(5, "px"), Length(5.0, "px")),
+        ("*", 5.0, Length(10, "px"), Length(50.0, "px")),
+        ("/", Length(10, "px"), 3.0, Length(10.0/3, "px")),
+        ("neg", Length(10, "px"), None, Length(-10, "px")),
+        ("+", Length(Decimal("10.5"), "px"), Length(Decimal("5.5"), "px"), Length(Decimal("16.0"), "px")),
+        ("-", Length(Decimal("10.5"), "px"), Length(Decimal("5.5"), "px"), Length(Decimal("5.0"), "px")),
+        ("*", Length(Decimal("10.5"), "px"), Decimal("2.0"), Length(Decimal("21.0"), "px")),
+        ("/", Length(Decimal("10.5"), "px"), Decimal("2.0"), Length(Decimal("5.25"), "px")),
+    ]
+)
+def test_length_operations(op, length1, length2, expected):
+    if op == "+":
+        assert length1 + length2 == expected
+    elif op == "-":
+        assert length1 - length2 == expected
+    elif op == "*":
+        assert length1 * length2 == expected
+    elif op == "/":
+        assert length1 / length2 == expected
+    elif op == "neg":
+        assert -length1 == expected
+    else:
+        raise ValueError("Unknown operation")
+
+
+@pytest.mark.parametrize(
+    "op, length1, length2, expected_exception",
+    [
+        ("+", Length(10, "px"), Length(5, "em"), ValueError),
+        ("-", Length(10, "px"), Length(5, "em"), ValueError),
+        ("*", Length(10, "px"), Length(5, "em"), TypeError),
+        ("/", Length(10, "px"), Length(5, "em"), TypeError),
+        ("+", Length(Decimal(10), "px"), Length(5.2, "px"), TypeError),  #decimal with float
+        ("-", Length(Decimal(10), "px"), Length(5.2, "px"), TypeError),  #decimal with float
+        ("*", Length(Decimal(10), "px"), Length(5.2, "px"), TypeError),  #decimal with float
+        ("/", Length(Decimal(10), "px"), Length(5.2, "px"), TypeError),  #decimal with float
+        ("+", Length(Decimal(10), "px"), 5.5, TypeError),  #decimal with different unit
+        ("-", Length(Decimal(10), "px"), 5.5, TypeError),  #decimal with different unit
+        ("*", Length(Decimal(10), "px"), 5.5, TypeError),  #decimal with different unit
+        ("/", Length(Decimal(10), "px"), 5.5, TypeError),  #decimal with different unit
+    ]
+)
+def test_length_exceptions(op, length1, length2, expected_exception):
+    with pytest.raises(expected_exception):
+        if op == "+":
+            _ = length1 + length2
+        elif op == "-":
+            _ = length1 - length2
+        elif op == "*":
+            _ = length1 * length2
+        elif op == "/":
+            _ = length1 / length2


### PR DESCRIPTION
with this modification, you can use svg.Length object as natural numbers 

It allows for code with operation on Length :

```python 
width = svg.Length(10, "em")
height = svg.Length(3, "em")

svg.Rect( 
   x = -width/2, y = -height/2
   width = width, height = height 
)
```

But you get errors when mixing units or incompatible number like Decimal and float
