### PR TITLE
Cleanup Set

### DIFF
--- a/svg/_mixins.py
+++ b/svg/_mixins.py
@@ -118,6 +118,7 @@ class Animation(AttrsMixin):
     values: str | None = None
     keyTimes: str | None = None
     keySplines: str | None = None
+    keyPoints: str | None = None
     from_: str | None = None
     to: str | None = None
     by: str | None = None

--- a/svg/elements.py
+++ b/svg/elements.py
@@ -708,7 +708,6 @@ class Animate(Element, m.Animation, m.Color, m.AnimationTiming, m.GraphicsElemen
     """
     element_name = "animate"
     externalResourcesRequired: bool | None = None
-    keyPoints: str | None = None
     attributeName: str | None = None
 
 
@@ -720,8 +719,6 @@ class Set(Element, m.AnimationTiming, m.GraphicsElementEvents):
     element_name = "set"
     externalResourcesRequired: bool | None = None
     to: str | None = None
-    min: str | None = None
-    keyPoints: str | None = None
     attributeName: str | None = None
     href: str | None = None
 
@@ -734,7 +731,6 @@ class AnimateMotion(Element, m.Animation, m.AnimationTiming, m.GraphicsElementEv
     element_name = "animateMotion"
     externalResourcesRequired: bool | None = None
     path: str | None = None
-    keyPoints: str | None = None
     rotate: str | None = None
     origin: str | None = None
 
@@ -757,7 +753,6 @@ class AnimateTransform(Element, m.Animation, m.AnimationTiming, m.GraphicsElemen
     element_name = "animateTransform"
     externalResourcesRequired: bool | None = None
     type: Literal["translate", "scale", "rotate", "skewX", "skewY"] | None = None
-    keyPoints: str | None = None
     attributeName: str | None = None
 
 


### PR DESCRIPTION
Mozilla Developer incorrectly lists keyPoints as being supported by Set.
https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/keyPoints
This is incorrect for several reasons:
- keyPoints is meaningless without keyTimes (which is not supported by Set)
- interpolation is entirely redundant anyways since Set represents an instantaneous change. 

The actual standard does not list it as part of Set https://svgwg.org/specs/animations/#SetElement

Moved keyPoints Attribute to the Animation Mixin
Removed an additional redundant min attribute from Set (already part of it via the AnimationTiming mixin).