### PR TITLE
Added Missing Attribute fill to the animation timing mixin

### DIFF
--- a/svg/_mixins.py
+++ b/svg/_mixins.py
@@ -140,3 +140,4 @@ class AnimationTiming(AttrsMixin):
     restart: Literal["always", "never", "whenNotActive"] | None = None
     repeatCount: str | None = None
     repeatDur: str | None = None
+    fill: Literal["freeze", "remove"] | None = None


### PR DESCRIPTION
Animation Timing was missing one attribute indicating how to handle the end of animations.
https://svgwg.org/specs/animations/#FillAttribute