### PR TITLE
Added Missing Literal Options to dur attribute

### DIFF
--- a/svg/_mixins.py
+++ b/svg/_mixins.py
@@ -135,7 +135,7 @@ class Animation(AttrsMixin):
 @dataclass
 class AnimationTiming(AttrsMixin):
     begin: str | None = None
-    dur: timedelta | None = None
+    dur: timedelta | Literal["media", "indefinite"] | None = None
     end: str | None = None
     min: timedelta | None = None
     max: timedelta | None = None


### PR DESCRIPTION
I missed that in #26.  See also https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/dur