### PR TITLE
Format clock under 60s as Timecount-val

### DIFF
--- a/examples/animate.svg
+++ b/examples/animate.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="100" height="100"><rect x="0" y="0" width="100" height="100"><animate dur="0:00:10" repeatCount="indefinite" values="0;50;0" attributeName="rx"/></rect></svg>
+<svg xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="100" height="100"><rect x="0" y="0" width="100" height="100"><animate dur="10s" repeatCount="indefinite" values="0;50;0" attributeName="rx"/></rect></svg>

--- a/examples/animate_transform.svg
+++ b/examples/animate_transform.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="120" height="120"><polygon points="60 30 90 90 30 90"><animateTransform dur="0:00:10" repeatCount="indefinite" from="0 60 70" to="360 60 70" type="rotate" attributeName="transform"/></polygon></svg>
+<svg xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="120" height="120"><polygon points="60 30 90 90 30 90"><animateTransform dur="10s" repeatCount="indefinite" from="0 60 70" to="360 60 70" type="rotate" attributeName="transform"/></polygon></svg>

--- a/svg/_types.py
+++ b/svg/_types.py
@@ -197,7 +197,13 @@ AnimationTimingEvent = Union[
 
 
 def to_clock_value(delta: timedelta) -> str:
+    """Format timedelta as ClockValue SVG type.
+
+    https://developer.mozilla.org/en-US/docs/Web/SVG/Guides/Content_type#clock-value
+    https://svgwg.org/specs/animations/#ClockValueSyntax
+    """
     seconds = delta.total_seconds()
+
     sign = ""
     if seconds < 0:
         sign = "-"
@@ -205,13 +211,21 @@ def to_clock_value(delta: timedelta) -> str:
 
     partial_seconds = seconds - math.floor(seconds)
     seconds = int(seconds)
+    fraction = ""
+    if partial_seconds > 0:
+        fraction = f"{partial_seconds:.6f}".strip("0")
+
+    # Format as Timecount-val.
+    if abs(seconds) < 60:
+        # The "s" suffix is optional but it's good for readability:
+        # in JS, time is represented in miliseconds, so
+        # just a number without a suffix may confuse JS engineers.
+        return f"{sign}{seconds}{fraction}s"
+
+    # Format as Full-clock-val.
     minutes, full_seconds = divmod(seconds, 60)
     hours, minutes = divmod(minutes, 60)
-
-    if partial_seconds > 0:
-        partial_second_str = f"{partial_seconds:.6f}".strip("0")
-        return f"{sign}{hours}:{minutes:02}:{full_seconds:02}{partial_second_str}"
-    return f"{sign}{hours}:{minutes:02}:{full_seconds:02}"
+    return f"{sign}{hours}:{minutes:02}:{full_seconds:02}{fraction}"
 
 
 def to_wallclock_sync_value(time: datetime) -> str:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -5,30 +5,42 @@ import pytest
 from svg._types import to_clock_value, to_wallclock_sync_value
 
 
-clock_values = [
-    (timedelta(seconds=10), "0:00:10"),
+@pytest.mark.parametrize("input, expected", [
+    # Timecount-val
+    (timedelta(), "0s"),
+    (timedelta(seconds=1), "1s"),
+    (timedelta(seconds=-1), "-1s"),
+    (timedelta(seconds=10), "10s"),
+    (timedelta(seconds=-10), "-10s"),
+    (timedelta(seconds=0.5), "0.5s"),
+    (timedelta(seconds=-0.5), "-0.5s"),
+    (timedelta(seconds=0.002), "0.002s"),
+    (timedelta(seconds=-0.002), "-0.002s"),
+    (timedelta(milliseconds=1), "0.001s"),
+    (timedelta(milliseconds=-1), "-0.001s"),
+
+    # Full-clock-val
     (timedelta(seconds=70), "0:01:10"),
-    (timedelta(seconds=0.5), "0:00:00.5"),
+    (timedelta(seconds=605), "0:10:05"),
     (timedelta(days=10), "240:00:00"),
     (timedelta(hours=5, minutes=7, seconds=12.2), "5:07:12.2"),
     (timedelta(hours=-1), "-1:00:00"),
-    (timedelta(seconds=-0.002), "-0:00:00.002"),
-    (timedelta(milliseconds=-1), "-0:00:00.001"),
-]
-
-
-@pytest.mark.parametrize("input, expected", clock_values)
+])
 def test_to_clock_value(input, expected):
     actual = to_clock_value(input)
     assert actual == expected
 
 
-wallclock_values = [
-    (datetime(year=2025, month=7, day=9), "wallclock(2025-07-09 00:00:00)"),
-    (datetime(year=1999, month=1, day=1, hour=13, minute=37, second=12, microsecond=4000), "wallclock(1999-01-01 13:37:12.004000)"),
-]
-
-@pytest.mark.parametrize("input, expected", wallclock_values)
+@pytest.mark.parametrize("input, expected", [
+    (
+        datetime(year=2025, month=7, day=9),
+        "wallclock(2025-07-09 00:00:00)",
+    ),
+    (
+        datetime(year=1999, month=1, day=1, hour=13, minute=37, second=12, microsecond=4000),
+        "wallclock(1999-01-01 13:37:12.004000)",
+    ),
+])
 def test_to_wallclock_sync_value(input, expected):
     actual = to_wallclock_sync_value(input)
     assert actual == expected


### PR DESCRIPTION
I noticed that vscode doesn't support animation timing value in `Full-clock-val` format. I thought about using `Timecount-val` for everything but `Full-clock-val` is more readable for long durations and I'm not sure if we should bend to support non-spec-compliant renderers. As a compromise, I adjusted the time formatter to use `Timecount-val` for durations under 60 seconds (which covers, I bet, the vast majority of animations) where it is both more readable and vscode-compatible.