### PR TITLE
Add IPython notebook rich display method

### DIFF
--- a/svg/elements.py
+++ b/svg/elements.py
@@ -113,6 +113,9 @@ class Element:
     def __str__(self) -> str:
         return self.as_str()
 
+    def _repr_svg_(self) -> str:
+        return self.as_str()
+
 
 @dataclass
 class SVG(


### PR DESCRIPTION
By providing [the appropriate `_repr_*_` method](https://ipython.readthedocs.io/en/stable/config/integrating.html), in this case the `svg` version, IPython will pick that up if it's the last item in a cell and automatically display it. 

### With change
<img width="397" height="338" alt="Screenshot 2025-09-27 at 19 37 32" src="https://github.com/user-attachments/assets/3e42af0a-0233-4018-afd4-17eaa582470d" />

### Before change
<img width="399" height="400" alt="Screenshot 2025-09-27 at 19 37 56" src="https://github.com/user-attachments/assets/341c354d-35e1-46fa-b569-de4d3e8b0eb5" />

Note that this doesn't create a dependency on IPython. If you never use IPython, this would just be a curiously named method on the class.

A possible downside would be if there's a gigantic SVG that the user doesn't want to implicitly show, this would. As it is, it would print out a ton of text, so a bit of 6 vs. half dozen. The usual solution for this predicament is to just not end a cell with an expression that returns non-`None`, like an assignment, function/method that returns `None`, or just a literal `None`.
