### PR TITLE
Add Point type for use in Polyline/Polygon for points list.

### DIFF
--- a/svg/__init__.py
+++ b/svg/__init__.py
@@ -22,7 +22,7 @@ from ._transforms import (
 from ._types import (
     Length, PreserveAspectRatio, ViewBoxSpec,
     TimeBezierPoint, SyncbaseValue, EventValue, RepeatValue, AccessKeyValue,
-    AnimationTimingEvent,
+    AnimationTimingEvent, Point,
 )
 from .elements import (
     SVG, A, Animate, AnimateMotion, AnimateTransform, Circle, ClipPath,

--- a/svg/_types.py
+++ b/svg/_types.py
@@ -238,3 +238,15 @@ def to_clock_value(delta: timedelta) -> str:
 def to_wallclock_sync_value(time: datetime) -> str:
     iso_time = time.isoformat(" ")
     return f"wallclock({iso_time})"
+
+
+@dataclass
+class Point:
+    """Point for use in Polygon and Polyline elements.
+    https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/points
+    """
+    x: Number
+    y: Number
+
+    def __str__(self) -> str:
+        return f"{self.x},{self.y}"

--- a/svg/elements.py
+++ b/svg/elements.py
@@ -8,7 +8,7 @@ from datetime import timedelta, datetime
 from . import _mixins as m
 from ._path import PathData
 from ._transforms import Transform
-from ._types import Length, Number, PreserveAspectRatio, ViewBoxSpec, to_clock_value, to_wallclock_sync_value
+from ._types import Length, Number, PreserveAspectRatio, ViewBoxSpec, to_clock_value, to_wallclock_sync_value, Point
 
 
 if TYPE_CHECKING:
@@ -420,7 +420,7 @@ class Polyline(Element, _FigureElement):
     element_name = "polyline"
     externalResourcesRequired: bool | None = None
     transform: list[Transform] | None = None
-    points: list[Number] | None = None
+    points: list[Point] | None = None
     marker_start: str | None = None
     marker_mid: str | None = None
     marker_end: str | None = None
@@ -440,7 +440,7 @@ class Polygon(Element, _FigureElement):
     element_name = "polygon"
     externalResourcesRequired: bool | None = None
     transform: list[Transform] | None = None
-    points: list[Number] | None = None
+    points: list[Point] | None = None
     marker_start: str | None = None
     marker_mid: str | None = None
     marker_end: str | None = None


### PR DESCRIPTION
Points will be output as a space-separated pair of comma-separated coordinates (eg: "x1,y1 x2,y2, x3,y3"). This also enforces the final list of coordinates to be even.

To preserve compatibility with old code, we could still allow for a list of number `points: list[Point] |list[Number] | None = None` as browser seems to accept a list of numbers 